### PR TITLE
ユーザーはエピソードの詳細を表示できる #33

### DIFF
--- a/src/app/(pages)/episodes/[id]/page.tsx
+++ b/src/app/(pages)/episodes/[id]/page.tsx
@@ -11,13 +11,13 @@ const buttonStyles: SxProps<Theme> = {
   width: "80%",
 };
 
-const StackStyle = {
+const StackStyle: SxProps<Theme> = {
   alignItems: "center",
   flexDirection: "row",
   gap: 1,
 };
 
-const commentTextStyle = {
+const commentTextStyle: SxProps<Theme> = {
   mx: 1,
 };
 

--- a/src/app/(pages)/episodes/error.tsx
+++ b/src/app/(pages)/episodes/error.tsx
@@ -1,0 +1,21 @@
+"use client";
+import { Box, Button, Typography } from "@mui/material";
+import { useRouter } from "next/navigation";
+
+import { HttpError } from "@/lib/http-error";
+
+const ErrorPage = ({ error }: { error: HttpError }) => {
+  const router = useRouter();
+  return (
+    <Box>
+      <Typography variant="h1">エラーが発生しました</Typography>
+      <Typography variant="h6">データベース接続エラーが発生しました。</Typography>
+      <Typography variant="h6">
+        {error.message} (ステータス: {error.status})
+      </Typography>
+      <Button onClick={() => router.push("/")}>ホームへ戻る</Button>
+    </Box>
+  );
+};
+
+export default ErrorPage;

--- a/src/app/(pages)/episodes/page.tsx
+++ b/src/app/(pages)/episodes/page.tsx
@@ -1,16 +1,19 @@
 import { Stack } from "@mui/material";
 import { Episode } from "@prisma/client";
 import Link from "next/link";
+import { notFound } from "next/navigation";
 
 import { WideCard } from "@/app/components/WideCard";
 import { getEpisodes } from "@/features/episodes/actions";
 
+const linkStyle = {
+  textDecoration: "none",
+};
+
 const EpisodesPage = async () => {
   const episodes = await getEpisodes();
 
-  if (!episodes) {
-    <p>エピソードがありません。</p>;
-  }
+  if (!episodes) notFound();
 
   return (
     <>
@@ -18,7 +21,9 @@ const EpisodesPage = async () => {
 
       <Stack spacing={5} mx={4}>
         {episodes.map((episode: Episode) => (
-          <WideCard key={episode.id} {...episode} />
+          <Link key={episode.id} href={`/episodes/${episode.id}`} passHref style={linkStyle}>
+            <WideCard {...episode} />
+          </Link>
         ))}
       </Stack>
     </>

--- a/src/features/episodes/actions.ts
+++ b/src/features/episodes/actions.ts
@@ -73,8 +73,7 @@ export async function getEpisode(episodeId: string) {
     });
     return res;
   } catch (e) {
-    console.error("Database Error", e);
-    return null;
+    prismaErrorHandler(e);
   }
 }
 
@@ -83,8 +82,7 @@ export async function getEpisodes() {
     const res = await prisma.episode.findMany();
     return res;
   } catch (e) {
-    console.error("Database Error", e);
-    return [];
+    prismaErrorHandler(e);
   }
 }
 


### PR DESCRIPTION
## チケットへのリンク

- #33 

## やったこと

- episodesの一覧ページからカードをクリックすると詳細ページに飛ぶようにLinkを仕込んだ。




## やらないこと

- その他のUI変更はしていない


## できるようになること（ユーザ目線）

- エピソードの一覧ページから詳細ページに遷移できるようになる

## できなくなること（ユーザ目線）

- なし


## 動作確認

- どのような動作確認を行ったのか？結果はどうか？

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
