### PR TITLE
ユーザーはカテゴリーを文字列で検索ができる #23

### DIFF
--- a/src/features/categories/actions.ts
+++ b/src/features/categories/actions.ts
@@ -9,6 +9,9 @@ import { prisma } from "@/lib/prisma";
 import { prismaErrorHandler } from "@/lib/prismaErrorHandler";
 import { validateSchema } from "@/lib/validation";
 
+type GetCategoriesParams = {
+  keyWord?: string;
+};
 const CategorySchema = z.object({
   id: z.string(),
   title: z.string(),
@@ -47,9 +50,13 @@ export async function getCategory(categoryId: string): Promise<Category | null> 
   }
 }
 
-export async function getCategories(): Promise<Category[]> {
+export async function getCategories(params: GetCategoriesParams): Promise<Category[]> {
   try {
-    const res = await prisma.category.findMany();
+    const res = await prisma.category.findMany({
+      where: {
+        ...(params.keyWord && { title: { contains: params.keyWord } }),
+      },
+    });
     return res;
   } catch (e) {
     console.error("Database Error", e);


### PR DESCRIPTION
## チケットへのリンク

- #23

## やったこと

全体方針
- 現在、一覧ページに表示されている全レコードをユーザーが入力した文字列を含んでいたら絞り込みを行い、条件にヒットしたレコードのみを表示するようにする。

- 絞り込みの方法としてフロント側でユーザーが入力した文字列をサーバー側に渡し、具体的にはprismaのwhereを使い条件付きの取得を行う。
参考：https://www.prisma.io/docs/orm/prisma-client/queries/filtering-and-sorting#filter-on-relations
- 今回の改修の対象となるgetCategoryは今後他のフィルターの拡張性を鑑みて、オブジェクト形式でparamsとして受け取るような進め方とする。


サーバー側
- getCategoryのwhereを追加。
- paramsの型定義を追加。


## やらないこと

フロント側の改修
- 検索ボタンの実行でrouter.pushを使い、カテゴリーの詳細ページにsearchParamsとして受け渡す
- 再レンダリングを行い、getCategoriesの引数として渡して、条件付きのレコードを受け取り、表示させる

本改修はバックエンドのレビュー完了後にプルリク作成予定。

イメージ
<img width="1439" alt="image" src="https://github.com/user-attachments/assets/05f7411a-c06a-4bda-a669-156df66053fb" />


## できるようになること（ユーザ目線）

- 検索窓に入れた文字列で絞り込みが行われる

## できなくなること（ユーザ目線）

-なし

## 動作確認

- どのような動作確認を行ったのか？結果はどうか？

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
