### PR TITLE
ユーザーはカテゴリーを文字列で検索ができる #23

### DIFF
--- a/src/app/(pages)/categories/page.tsx
+++ b/src/app/(pages)/categories/page.tsx
@@ -5,8 +5,10 @@ import { ViewAction } from "@/app/components/ViewAction";
 import { ViewCard } from "@/app/components/ViewCard";
 import { getCategories } from "@/features/categories/actions";
 
-const CategoriesPage = async () => {
-  const categories = await getCategories();
+const CategoriesPage = async ({ searchParams }: { searchParams: { keyWord?: string } }) => {
+  const keyWord = searchParams.keyWord ?? "";
+  const categories = await getCategories({ keyWord: keyWord });
+
   if (!categories) notFound();
 
   return (

--- a/src/app/components/ViewAction.tsx
+++ b/src/app/components/ViewAction.tsx
@@ -1,13 +1,25 @@
+"use client";
 import { Search } from "@mui/icons-material";
 import { Button, Grid2, InputAdornment, TextField } from "@mui/material";
-import React from "react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
 
 export const ViewAction = ({ viewType }: { viewType: string }) => {
+  const [keyWord, setKeyWord] = useState("");
+  const router = useRouter();
+
+  const handleSearch = () => {
+    const query = keyWord ? `?keyWord=${encodeURIComponent(keyWord)}` : "";
+    router.push(`/${viewType}${query}`);
+  };
+
   return (
     <Grid2 container spacing={1} m={3}>
       <TextField
         variant="standard"
         color="secondary"
+        value={keyWord}
+        onChange={(e) => setKeyWord(e.target.value)}
         slotProps={{
           input: {
             startAdornment: (
@@ -18,7 +30,7 @@ export const ViewAction = ({ viewType }: { viewType: string }) => {
           },
         }}
       />
-      <Button variant="outlined" color="secondary">
+      <Button variant="outlined" color="secondary" aria-label="検索" onClick={handleSearch}>
         検索
       </Button>
 


### PR DESCRIPTION
## チケットへのリンク

- #23 

## やったこと

- 共通コンポーネントの検索窓にて入力した文字列を取得できるようにした
- カテゴリーの一覧で入力した文字列でデータを絞り込み、その結果を返すようにした

## やらないこと

- なし

## できるようになること（ユーザ目線）

- 検索窓に入力した文字列で検索できる

## できなくなること（ユーザ目線）

- なし

## 動作確認

- どのような動作確認を行ったのか？結果はどうか？

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
