### PR TITLE
ユーザーはエピソードを文字列で検索ができる #35

### DIFF
--- a/src/features/episodes/actions.ts
+++ b/src/features/episodes/actions.ts
@@ -30,6 +30,7 @@ const DeleteEpisodeSchema = EpisodeSchema.omit({
 
 type GetEpisodesParams = {
   channelId?: string;
+  keyWord?: string;
 };
 
 export async function createEpisode(formData: FormData) {
@@ -98,8 +99,8 @@ export async function getEpisodes(params: GetEpisodesParams = {}) {
   try {
     const res = await prisma.episode.findMany({
       where: {
-        // const where = params.channelId ? { validChannel: params.channelId } : {};の三項演算子と同じ意味。
         ...(params.channelId && { channelId: params.channelId }),
+        ...(params.keyWord && { title: { contains: params.keyWord } }),
       },
     });
 


### PR DESCRIPTION
## チケットへのリンク

- #35 

## やったこと

全体方針
- 現在、一覧ページに表示されている全レコードをユーザーが入力した文字列を含んでいたら絞り込みを行い、条件にヒットしたレコードのみを表示するようにする。

- 絞り込みの方法としてフロント側でユーザーが入力した文字列をサーバー側に渡し、具体的にはprismaのwhereを使い条件付きの取得を行う。
参考：https://www.prisma.io/docs/orm/prisma-client/queries/filtering-and-sorting#filter-on-relations
- 今回の改修の対象となるgetEPisodesは今後他のフィルターの拡張性を鑑みて、オブジェクト形式でparamsとして受け取るような進め方とする。


サーバー側
- getEpisodesのwhereを追加。
- paramsの型定義を追加。


## やらないこと

フロント側の改修
- 再レンダリングを行い、getEpisodesの引数として渡して、条件付きのレコードを受け取り、表示させる

本改修はバックエンドのレビュー完了後にプルリク作成予定。

イメージ
<img width="1435" alt="image" src="https://github.com/user-attachments/assets/6246d561-fa93-4501-83db-f10a0548ab41" />


## できるようになること（ユーザ目線）

- 検索窓に入れた文字列で絞り込みが行われる

## できなくなること（ユーザ目線）

-なし

## 動作確認

- どのような動作確認を行ったのか？結果はどうか？

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
