### PR TITLE
ユーザーはチャンネルを文字列で検索ができる #29

### DIFF
--- a/src/features/channels/actions.ts
+++ b/src/features/channels/actions.ts
@@ -22,6 +22,7 @@ const DeleteChannelSchema = ChannelSchema.omit({ title: true, categoryId: true, 
 
 type GetChannelsParams = {
   appUserId?: string;
+  keyWord?: string;
 };
 
 export async function createChannel(formData: FormData) {
@@ -63,8 +64,8 @@ export async function getChannels(params: GetChannelsParams = {}) {
   try {
     const res = await prisma.channel.findMany({
       where: {
-        // const where = params.appUserId ? { validChannel: params.appUserId } : {};の三項演算子と同じ意味。
         ...(params.appUserId && { appUserId: params.appUserId }),
+        ...(params.keyWord && { title: { contains: params.keyWord } }),
       },
     });
     return res;


### PR DESCRIPTION
## チケットへのリンク

- #29  

## やったこと

全体方針
- 現在、一覧ページに表示されている全レコードをユーザーが入力した文字列を含んでいたら絞り込みを行い、条件にヒットしたレコードのみを表示するようにする。

- 絞り込みの方法としてフロント側でユーザーが入力した文字列をサーバー側に渡し、具体的にはprismaのwhereを使い条件付きの取得を行う。
参考：https://www.prisma.io/docs/orm/prisma-client/queries/filtering-and-sorting#filter-on-relations
- 今回の改修の対象となるgetChannelsは今後他のフィルターの拡張性を鑑みて、オブジェクト形式でparamsとして受け取るような進め方とする。


サーバー側
- getChannelsのwhereを追加。
- paramsの型定義を追加。


## やらないこと

フロント側の改修
- 再レンダリングを行い、getChannelsの引数として渡して、条件付きのレコードを受け取り、表示させる

本改修はバックエンドのレビュー完了後にプルリク作成予定。

イメージ
<img width="1067" alt="image" src="https://github.com/user-attachments/assets/e7ee7189-13bc-4af5-9566-f4a64e573c82" />




## できるようになること（ユーザ目線）

- 検索窓に入れた文字列で絞り込みが行われる

## できなくなること（ユーザ目線）

-なし

## 動作確認

- どのような動作確認を行ったのか？結果はどうか？

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
