### PR TITLE
prismaのget系の異常系のハンドリングのリファクタリング #95

### DIFF
--- a/src/features/categories/actions.ts
+++ b/src/features/categories/actions.ts
@@ -1,6 +1,5 @@
 "use server";
 
-import { Category } from "@prisma/client";
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { z } from "zod";
@@ -30,13 +29,14 @@ export async function createCategory(formData: FormData) {
       },
     });
   } catch (e) {
-    return prismaErrorHandler(e);
+    // handler内のthrowで終了する関数なので return 不要
+    prismaErrorHandler(e);
   }
   revalidatePath("/categories");
   redirect("/categories");
 }
 
-export async function getCategory(categoryId: string): Promise<Category | null> {
+export async function getCategory(categoryId: string) {
   try {
     const res = await prisma.category.findUnique({
       where: {
@@ -45,12 +45,12 @@ export async function getCategory(categoryId: string): Promise<Category | null> 
     });
     return res;
   } catch (e) {
-    console.error("Database Error", e);
-    return null;
+    // handler内のthrowで終了する関数なので return 不要
+    prismaErrorHandler(e);
   }
 }
 
-export async function getCategories(params: GetCategoriesParams): Promise<Category[]> {
+export async function getCategories(params: GetCategoriesParams) {
   try {
     const res = await prisma.category.findMany({
       where: {
@@ -59,8 +59,8 @@ export async function getCategories(params: GetCategoriesParams): Promise<Catego
     });
     return res;
   } catch (e) {
-    console.error("Database Error", e);
-    return [];
+    // handler内のthrowで終了する関数なので return 不要
+    prismaErrorHandler(e);
   }
 }
 
@@ -80,7 +80,8 @@ export async function updateCategory(formData: FormData) {
       },
     });
   } catch (e) {
-    return prismaErrorHandler(e);
+    // handler内のthrowで終了する関数なので return 不要
+    prismaErrorHandler(e);
   }
 
   revalidatePath("/categories");
@@ -99,7 +100,8 @@ export async function deleteCategory(formData: FormData) {
       },
     });
   } catch (e) {
-    return prismaErrorHandler(e);
+    // handler内のthrowで終了する関数なので return 不要
+    prismaErrorHandler(e);
   }
 
   revalidatePath("/categories");

--- a/src/features/categories/relations/actions.ts
+++ b/src/features/categories/relations/actions.ts
@@ -22,7 +22,8 @@ export async function getChannelsByCategory(categoryId: string) {
     );
     return channels;
   } catch (e) {
-    return prismaErrorHandler(e);
+    // handler内のthrowで終了する関数なので return 不要
+    prismaErrorHandler(e);
   }
 }
 
@@ -45,6 +46,7 @@ export async function getEpisodesByCategory(categoryId: string) {
     );
     return episodes;
   } catch (e) {
-    return prismaErrorHandler(e);
+    // handler内のthrowで終了する関数なので return 不要
+    prismaErrorHandler(e);
   }
 }

--- a/src/features/channels/actions.ts
+++ b/src/features/channels/actions.ts
@@ -1,6 +1,5 @@
 "use server";
 
-import { Channel } from "@prisma/client";
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { z } from "zod";
@@ -53,7 +52,8 @@ export async function createChannel(formData: FormData) {
       });
     });
   } catch (e) {
-    return prismaErrorHandler(e);
+    // handler内のthrowで終了する関数なので return 不要
+    prismaErrorHandler(e);
   }
   revalidatePath("/channels");
   redirect("/channels");
@@ -69,12 +69,12 @@ export async function getChannels(params: GetChannelsParams = {}) {
     });
     return res;
   } catch (e) {
-    console.error("Database Error", e);
-    return [];
+    // handler内のthrowで終了する関数なので return 不要
+    prismaErrorHandler(e);
   }
 }
 
-export async function getChannel(channelId: string): Promise<Channel | null> {
+export async function getChannel(channelId: string) {
   try {
     const res = await prisma.channel.findUnique({
       where: {
@@ -84,8 +84,8 @@ export async function getChannel(channelId: string): Promise<Channel | null> {
 
     return res;
   } catch (e) {
-    console.error("Database Error:", e);
-    return null;
+    // handler内のthrowで終了する関数なので return 不要
+    prismaErrorHandler(e);
   }
 }
 
@@ -120,7 +120,8 @@ export async function updateChannel(formData: FormData) {
       });
     });
   } catch (e) {
-    return prismaErrorHandler(e);
+    // handler内のthrowで終了する関数なので return 不要
+    prismaErrorHandler(e);
   }
   revalidatePath("/channels");
   redirect("/channels");
@@ -148,7 +149,8 @@ export async function deleteChannel(formData: FormData) {
       });
     });
   } catch (e) {
-    return prismaErrorHandler(e);
+    // handler内のthrowで終了する関数なので return 不要
+    prismaErrorHandler(e);
   }
   revalidatePath("/channels");
   redirect("/channels");

--- a/src/features/comments/actions.ts
+++ b/src/features/comments/actions.ts
@@ -32,7 +32,8 @@ export async function CreateComment(formData: FormData) {
       },
     });
   } catch (e) {
-    return prismaErrorHandler(e);
+    // handler内のthrowで終了する関数なので return 不要
+    prismaErrorHandler(e);
   }
   revalidatePath(`/episodes${validComment.episodeId}`);
 }
@@ -61,6 +62,7 @@ export async function getComments(episodeId: string) {
 
     return formattedComments;
   } catch (e) {
-    console.error("Database Error:", e);
+    // handler内のthrowで終了する関数なので return 不要
+    prismaErrorHandler(e);
   }
 }

--- a/src/features/episodes/actions.ts
+++ b/src/features/episodes/actions.ts
@@ -73,7 +73,8 @@ export async function createEpisode(formData: FormData) {
       });
     });
   } catch (e) {
-    return prismaErrorHandler(e);
+    // handler内のthrowで終了する関数なので return 不要
+    prismaErrorHandler(e);
   }
 
   revalidatePath("/episodes");
@@ -147,7 +148,8 @@ export async function updateEpisode(formData: FormData) {
       });
     });
   } catch (e) {
-    return prismaErrorHandler(e);
+    // handler内のthrowで終了する関数なので return 不要
+    prismaErrorHandler(e);
   }
   revalidatePath("/episodes");
   redirect("/episodes");
@@ -173,7 +175,8 @@ export async function deleteEpisode(formData: FormData) {
       });
     });
   } catch (e) {
-    return prismaErrorHandler(e);
+    // handler内のthrowで終了する関数なので return 不要
+    prismaErrorHandler(e);
   }
   revalidatePath("/episodes");
   redirect("/episodes");

--- a/src/features/users/actions.ts
+++ b/src/features/users/actions.ts
@@ -1,7 +1,6 @@
 "use server";
 
 import { SessionData } from "@auth0/nextjs-auth0/types";
-import { User } from "@prisma/client";
 import { cache } from "react";
 import { z } from "zod";
 
@@ -62,7 +61,8 @@ export async function upsertAppUser(sessionData: SessionData) {
       }
       return res;
     } catch (e) {
-      return prismaErrorHandler(e);
+      // handler内のthrowで終了する関数なので return 不要
+      prismaErrorHandler(e);
     }
   } catch (e) {
     console.error("Database Error", e);
@@ -87,11 +87,12 @@ export const updateAppUser = async (formData: FormData) => {
       },
     });
   } catch (e) {
-    return prismaErrorHandler(e);
+    // handler内のthrowで終了する関数なので return 不要
+    prismaErrorHandler(e);
   }
 };
 
-export const getAppUser = cache(async (id: string): Promise<User | null> => {
+export const getAppUser = cache(async (id: string) => {
   try {
     const appUser = await prisma.user.findUnique({
       where: { id },
@@ -99,8 +100,8 @@ export const getAppUser = cache(async (id: string): Promise<User | null> => {
 
     return appUser;
   } catch (e) {
-    console.error("DatabaseError", e);
-    return null;
+    // handler内のthrowで終了する関数なので return 不要
+    prismaErrorHandler(e);
   }
 });
 
@@ -113,8 +114,8 @@ export const getAppUsers = async (role: string) => {
 
     return allUsers;
   } catch (e) {
-    console.error("DatabaseError", e);
-    return [];
+    // handler内のthrowで終了する関数なので return 不要
+    prismaErrorHandler(e);
   }
 };
 
@@ -137,6 +138,7 @@ export const deactivateAppUser = async (deactivateInfo: DeactivateUserInfo) => {
       });
     }
   } catch (e) {
-    return prismaErrorHandler(e);
+    // handler内のthrowで終了する関数なので return 不要
+    prismaErrorHandler(e);
   }
 };


### PR DESCRIPTION
## チケットへのリンク

- #95 

## やったこと

- get系の取得のエラーにおいて、nullや[]を返すなどエラー後の返り値がバラバラとなっていたため、エラーのハンドリングを共通化した。

## やらないこと

- このプルリクでやらないことは何か？（あれば。無いなら「無し」で OK）（やらない場合は、いつやるのかを明記する。）

## できるようになること（ユーザ目線）

- 何ができるようになるのか？（あれば。無いなら「無し」で OK）

## できなくなること（ユーザ目線）

- 何ができなくなるのか？（あれば。無いなら「無し」で OK）

## 動作確認

- どのような動作確認を行ったのか？結果はどうか？

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
