### PR TITLE
ユーザーはエピソードを文字列で検索ができる #35 フロント対応

### DIFF
--- a/src/app/(pages)/episodes/page.tsx
+++ b/src/app/(pages)/episodes/page.tsx
@@ -3,6 +3,7 @@ import { Episode } from "@prisma/client";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
+import { ViewAction } from "@/app/components/ViewAction";
 import { WideCard } from "@/app/components/WideCard";
 import { getEpisodes } from "@/features/episodes/actions";
 
@@ -10,16 +11,16 @@ const linkStyle = {
   textDecoration: "none",
 };
 
-const EpisodesPage = async () => {
-  const episodes = await getEpisodes();
+const EpisodesPage = async ({ searchParams }: { searchParams: { keyWord?: string } }) => {
+  const keyWord = searchParams.keyWord ?? "";
+  const episodes = await getEpisodes({ keyWord: keyWord });
 
   if (!episodes) notFound();
 
   return (
     <>
-      <Link href="/episodes/create">新規作成</Link>
-
-      <Stack spacing={5} mx={4}>
+      <ViewAction viewType="episodes" />
+      <Stack spacing={5} mx={3}>
         {episodes.map((episode: Episode) => (
           <Link key={episode.id} href={`/episodes/${episode.id}`} passHref style={linkStyle}>
             <WideCard {...episode} />


### PR DESCRIPTION
## チケットへのリンク

- #35

## やったこと

- エピソードの一覧で入力した文字列でデータを絞り込み、その結果を返すようにした

## やらないこと

なし


## できるようになること（ユーザ目線）

- 検索窓に入力した文字列で検索できる

## できなくなること（ユーザ目線）

なし
## 動作確認

- どのような動作確認を行ったのか？結果はどうか？

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
