### PR TITLE
ユーザーはマイページを閲覧できる #16 フロント対応

### DIFF
--- a/src/app/(pages)/users/[id]/page.tsx
+++ b/src/app/(pages)/users/[id]/page.tsx
@@ -1,9 +1,16 @@
 import { AccountCircle } from "@mui/icons-material";
-import { Avatar, Box, Card, Divider, Grid2, Stack, Typography } from "@mui/material";
+import { Avatar, Box, Card, Divider, Grid2, Stack, SxProps, Theme, Typography } from "@mui/material";
 import { notFound } from "next/navigation";
 
 import { getValidSession } from "@/features/auth/actions";
 import { getAppUser } from "@/features/users/actions";
+
+const cardStyle: SxProps<Theme> = {
+  maxWidth: 480,
+  mt: 5,
+  mx: "auto",
+  width: "100%",
+};
 
 export const Page = async () => {
   const session = await getValidSession();
@@ -12,15 +19,7 @@ export const Page = async () => {
   if (!appUser) notFound();
 
   return (
-    <Card
-      variant="outlined"
-      sx={{
-        maxWidth: 480,
-        mt: 5,
-        mx: "auto",
-        width: "100%",
-      }}
-    >
+    <Card variant="outlined" sx={cardStyle}>
       <Grid2 display="flex" justifyContent="center" alignItems="center" my={5}>
         <Grid2 mr={3}>
           <Avatar>

--- a/src/app/(pages)/users/[id]/page.tsx
+++ b/src/app/(pages)/users/[id]/page.tsx
@@ -1,4 +1,5 @@
-import Link from "next/link";
+import { AccountCircle } from "@mui/icons-material";
+import { Avatar, Box, Card, Divider, Grid2, Stack, Typography } from "@mui/material";
 import { notFound } from "next/navigation";
 
 import { getValidSession } from "@/features/auth/actions";
@@ -11,12 +12,34 @@ export const Page = async () => {
   if (!appUser) notFound();
 
   return (
-    <>
-      <div>{appUser.name}</div>
-      <div>{appUser.email}</div>
-      <div>{appUser.role}</div>
-      <Link href={`/users/${appUser.id}/edit`}>編集</Link>
-    </>
+    <Card
+      variant="outlined"
+      sx={{
+        maxWidth: 480,
+        mt: 5,
+        mx: "auto",
+        width: "100%",
+      }}
+    >
+      <Grid2 display="flex" justifyContent="center" alignItems="center" my={5}>
+        <Grid2 mr={3}>
+          <Avatar>
+            <AccountCircle fontSize="large" />
+          </Avatar>
+        </Grid2>
+        <Stack spacing={1}>
+          <Typography variant="h5">{appUser.name}</Typography>
+          <Typography>{appUser.email}</Typography>
+        </Stack>
+      </Grid2>
+      <Grid2>
+        <Divider />
+        <Box mt={2} textAlign="center" width="100%" mx="auto">
+          <Typography>自己紹介</Typography>
+          <Typography p={3}>{appUser.description}</Typography>
+        </Box>
+      </Grid2>
+    </Card>
   );
 };
 


### PR DESCRIPTION
## チケットへのリンク

- #16 

## やったこと

- マイページにて、ユーザー名・メールアドレス・自己紹介文を表示できるようにスタイルを変更した。
<img width="1431" alt="image" src="https://github.com/user-attachments/assets/3e2c0971-3c39-4fcb-8cf5-0659b25fa852" />



## やらないこと

- 機能の追加は特になし

## できるようになること（ユーザ目線）

- なし

## できなくなること（ユーザ目線）

- なし

## 動作確認

- どのような動作確認を行ったのか？結果はどうか？

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
