### PR TITLE
ユーザーはマイページを更新できる #17 フロント対応

### DIFF
--- a/src/app/(pages)/users/[id]/edit/page.tsx
+++ b/src/app/(pages)/users/[id]/edit/page.tsx
@@ -1,8 +1,17 @@
+import { AccountCircle } from "@mui/icons-material";
+import { Avatar, Button, Card, Grid2, Stack, SxProps, TextField, Theme } from "@mui/material";
 import { notFound } from "next/navigation";
 
 import { DeactivateButton } from "@/app/components/DeactivateButton";
 import { getValidSession } from "@/features/auth/actions";
 import { getAppUser, updateAppUser } from "@/features/users/actions";
+
+const cardStyle: SxProps<Theme> = {
+  maxWidth: 480,
+  mt: 5,
+  mx: "auto",
+  width: "100%",
+};
 
 const page = async () => {
   const session = await getValidSession();
@@ -12,12 +21,31 @@ const page = async () => {
 
   return (
     <>
-      <form method="POST" action={updateAppUser}>
-        <input name="appUserId" hidden defaultValue={appUser.id} />
-        <input type="text" name="userName" required defaultValue={appUser.name} />
-        <input type="text" name="userEmail" required defaultValue={appUser.email} />
-        <button>更新</button>
-      </form>
+      <Card variant="outlined" sx={cardStyle}>
+        <Grid2 display="flex" justifyContent="center" mt={4}>
+          <Avatar>
+            <AccountCircle fontSize="large" />
+          </Avatar>
+        </Grid2>
+        <form action={updateAppUser}>
+          <Stack m={3} spacing={3}>
+            <input name="appUserId" hidden defaultValue={appUser.id} />
+            <TextField label="ユーザー名" defaultValue={appUser.name} name="appUserName"></TextField>
+            <TextField label="メールアドレス" defaultValue={appUser.email} name="appUserEmail"></TextField>
+            <TextField
+              label="自己紹介文"
+              multiline
+              defaultValue={appUser.description}
+              name="appUserDescription"
+            ></TextField>
+          </Stack>
+          <Grid2 display="flex" justifyContent="center" m={5}>
+            <Button variant="contained" type="submit">
+              保存
+            </Button>
+          </Grid2>
+        </form>
+      </Card>
       <DeactivateButton
         deactivateInfo={{
           appUserId: appUser.id,

--- a/src/app/(pages)/users/[id]/edit/page.tsx
+++ b/src/app/(pages)/users/[id]/edit/page.tsx
@@ -2,7 +2,6 @@ import { AccountCircle } from "@mui/icons-material";
 import { Avatar, Button, Card, Grid2, Stack, SxProps, TextField, Theme } from "@mui/material";
 import { notFound } from "next/navigation";
 
-import { DeactivateButton } from "@/app/components/DeactivateButton";
 import { getValidSession } from "@/features/auth/actions";
 import { getAppUser, updateAppUser } from "@/features/users/actions";
 
@@ -46,13 +45,13 @@ const page = async () => {
           </Grid2>
         </form>
       </Card>
-      <DeactivateButton
+      {/* <DeactivateButton
         deactivateInfo={{
           appUserId: appUser.id,
           loginUserId: session.user.appUserId,
           loginUserRole: session.user.role,
         }}
-      />
+      /> */}
     </>
   );
 };

--- a/src/app/(pages)/users/[id]/page.tsx
+++ b/src/app/(pages)/users/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { AccountCircle } from "@mui/icons-material";
-import { Avatar, Box, Card, Divider, Grid2, Stack, SxProps, Theme, Typography } from "@mui/material";
+import { Avatar, Box, Button, Card, Divider, Grid2, Stack, SxProps, Theme, Typography } from "@mui/material";
+import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { getValidSession } from "@/features/auth/actions";
@@ -19,26 +20,33 @@ export const Page = async () => {
   if (!appUser) notFound();
 
   return (
-    <Card variant="outlined" sx={cardStyle}>
-      <Grid2 display="flex" justifyContent="center" alignItems="center" my={5}>
-        <Grid2 mr={3}>
-          <Avatar>
-            <AccountCircle fontSize="large" />
-          </Avatar>
+    <>
+      <Card variant="outlined" sx={cardStyle}>
+        <Grid2 display="flex" justifyContent="center" alignItems="center" my={5}>
+          <Grid2 mr={3}>
+            <Avatar>
+              <AccountCircle fontSize="large" />
+            </Avatar>
+          </Grid2>
+          <Stack spacing={1}>
+            <Typography variant="h5">{appUser.name}</Typography>
+            <Typography>{appUser.email}</Typography>
+          </Stack>
         </Grid2>
-        <Stack spacing={1}>
-          <Typography variant="h5">{appUser.name}</Typography>
-          <Typography>{appUser.email}</Typography>
-        </Stack>
+        <Grid2>
+          <Divider />
+          <Box mt={2} textAlign="center" width="100%" mx="auto">
+            <Typography>自己紹介</Typography>
+            <Typography p={3}>{appUser.description}</Typography>
+          </Box>
+        </Grid2>
+      </Card>
+      <Grid2 display="flex" justifyContent="center" m={5}>
+        <Link href={`/users/${appUser.id}/edit`} passHref>
+          <Button variant="contained">編集する</Button>
+        </Link>
       </Grid2>
-      <Grid2>
-        <Divider />
-        <Box mt={2} textAlign="center" width="100%" mx="auto">
-          <Typography>自己紹介</Typography>
-          <Typography p={3}>{appUser.description}</Typography>
-        </Box>
-      </Grid2>
-    </Card>
+    </>
   );
 };
 


### PR DESCRIPTION
## チケットへのリンク

- #17 

## やったこと

- user/[id]/editで編集ができるようスタイルを変更した。
<img width="1430" alt="image" src="https://github.com/user-attachments/assets/422b5cc0-7f50-4aa9-9d0f-7b771f0cd248" />


## やらないこと

- 追加の機能実装。

## できるようになること（ユーザ目線）

- ヘッダーからマイページに遷移し、編集ボタンを押下後、編集画面に遷移できる
- 編集画面で、ユーザー名やメールアドレス・自己紹介文を編集し、保存できる


## できなくなること（ユーザ目線）

- なし

## 動作確認

- どのような動作確認を行ったのか？結果はどうか？

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
